### PR TITLE
[Compute] Autogen PR Issue 51

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,12 @@
 
 -->
 ## Upcoming Release
+* Added new parameter `-SharingProfile` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` cmdlets.
+    - The `SharingProfile` parameter is an array of strings that contains an array of Arm resource ids of subscriptions.
+    - Example: "/subscriptions/{subscriptionId1}", "/subscriptions/{subscriptionId2}"
+* Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.
+* Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.
+* Updated Azure.Core to 1.33.0.
 * Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.
 * Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.
 * Updated Azure.Core to 1.33.0.

--- a/src/Compute/Compute/Generated/CapacityReservation/NewAzCapacityReservationGroupCommand.cs
+++ b/src/Compute/Compute/Generated/CapacityReservation/NewAzCapacityReservationGroupCommand.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,6 +70,10 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             Mandatory = false)]
         public string[] Zone { get; set; }
 
+        [Parameter(
+            Mandatory = false)]
+        public string[] SharingProfile { get; set; }
+
         public override void ExecuteCmdlet()
         {
             base.ExecuteCmdlet();
@@ -88,6 +92,10 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                     {
                         capacityReservationGroup.Zones = this.Zone;
                     }
+                    if (this.IsParameterBound(c => c.SharingProfile))
+                    {
+                        capacityReservationGroup.SharingProfile = this.SharingProfile;
+                    }
 
                     var result = CapacityReservationGroupClient.CreateOrUpdate(this.ResourceGroupName, this.Name, capacityReservationGroup);
                     var psObject = new PSCapacityReservationGroup();
@@ -98,3 +106,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         }
     }
 }
+

--- a/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
+++ b/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.Management.Compute.Models;
@@ -16,5 +16,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public IList<SubResourceReadOnly> VirtualMachinesAssociated { get; set; }
         public CapacityReservationGroupInstanceView InstanceView { get; set; }
         public IList<string> Zones { get; set; }
+        public string[] SharingProfile { get; set; }
     }
 }


### PR DESCRIPTION
resolves https://github.com/haagha/azure-powershell-cmdlet-review-pr/issues/51 "\n" * Added new parameter `-SharingProfile` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` cmdlets.~    - The `SharingProfile` parameter is an array of strings that contains an array of Arm resource ids of subscriptions.~    - Example: "/subscriptions/{subscriptionId1}", "/subscriptions/{subscriptionId2}"~* Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.~* Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.~* Updated Azure.Core to 1.33.0.~