### PR TITLE
[Compute] Autogen PR Issue 51

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,12 @@
 
 -->
 ## Upcoming Release
+* Added new parameter `-SharingProfile` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` cmdlets.
+    - The `SharingProfile` parameter is an array of strings that contains an array of Arm resource ids of subscriptions.
+    - Example: "/subscriptions/{subscriptionId1}", "/subscriptions/{subscriptionId2}"
+* Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.
+* Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.
+* Updated Azure.Core to 1.33.0.
 * Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.
 * Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.
 * Updated Azure.Core to 1.33.0.


### PR DESCRIPTION
resolves https://github.com/haagha/azure-powershell-cmdlet-review-pr/issues/51 \\n * Added new parameter `-SharingProfile` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` cmdlets.    - The `SharingProfile` parameter is an array of strings that contains an array of Arm resource ids of subscriptions.    - Example: "/subscriptions/{subscriptionId1}", "/subscriptions/{subscriptionId2}"* Fixed the `Update-AzVmss` cmdlet so the `AutomaticRepairGracePeriod`, `AutomaticRepairAction`, and `EnableAutomaticRepair` parameters function correctly.* Updated help doc for `New-AzVM`, `New-AzVMConfig`, `New-AzVmss`, `New-AzVmssConfig`, `Update-AzVM`, and `Update-AzVmss` to include parameters that were previously added for Trusted Launch features.* Updated Azure.Core to 1.33.0.